### PR TITLE
Add support for NumPy scalars

### DIFF
--- a/src/scientific_pydantic/numpy/__init__.py
+++ b/src/scientific_pydantic/numpy/__init__.py
@@ -4,6 +4,8 @@ The current supported types are:
 
 - `dtype` - [DTypeAdapter][scientific_pydantic.numpy.DTypeAdapter]
 - `ndarray` - [NDArrayAdapter][scientific_pydantic.numpy.NDArrayAdapter]
+- `bool_`, `integer`, `inexact` -
+      [ScalarAdapter][scientific_pydantic.numpy.ScalarAdapter]
 """
 
 from .dtype_adapter import DTypeAdapter

--- a/src/scientific_pydantic/numpy/__init__.py
+++ b/src/scientific_pydantic/numpy/__init__.py
@@ -8,8 +8,10 @@ The current supported types are:
 
 from .dtype_adapter import DTypeAdapter
 from .ndarray_adapter import NDArrayAdapter
+from .scalar_adapter import ScalarAdapter
 
 __all__ = [
     "DTypeAdapter",
     "NDArrayAdapter",
+    "ScalarAdapter",
 ]

--- a/src/scientific_pydantic/numpy/scalar_adapter.py
+++ b/src/scientific_pydantic/numpy/scalar_adapter.py
@@ -25,8 +25,8 @@ class ScalarAdapter:
     ------------------
     1. Matching numpy scalar type - identity pass-through.
     2. Any other numpy scalar - cast via the target type's constructor.
-    3. Python ``int``, ``float``, ``bool``, ``str`` - converted via the
-       target type's constructor.
+    3. Python ``int``, ``float``, ``bool``, ``str``, ``complex`` - converted via
+       the target type's constructor.
 
     JSON Serialization
     ------------------
@@ -99,37 +99,25 @@ class ScalarAdapter:
             msg = f"Source type {source_type} was not a supported NumPy scalar type"
             raise PydanticSchemaGenerationError(msg)
 
-        kind: str = np.dtype(source_type).kind
-
-        before_validator = _build_before_validator(source_type)
         bounds_validator = _build_bounds_validator(
             source_type, gt=self._gt, ge=self._ge, lt=self._lt, le=self._le
-        )
-        after_validators: list[ty.Callable[[ty.Any], ty.Any]] = (
-            [bounds_validator] if bounds_validator is not None else []
-        )
-
-        # Insert the custom description
-        desc = self._get_json_description(source_type)
-        json_schema = _np_json_schema(kind)
-        json_schema["metadata"] = {
-            "pydantic_js_functions": [lambda c, h: h(c) | {"description": desc}]
-        }
-
-        encoding = (
-            self._encoding
-            if self._encoding is not None
-            else Encoding(
-                serializer=_serializer,
-                before_validator=before_validator,
-                json_schema=json_schema,
-            )
         )
 
         return make_core_schema(
             source_type,
-            encoding=encoding,
-            after_validators=after_validators,
+            encoding=(
+                self._encoding
+                if self._encoding is not None
+                else Encoding(
+                    serializer=_serializer,
+                    before_validator=_build_before_validator(source_type),
+                    json_schema=_np_json_schema(
+                        np.dtype(source_type).kind,
+                        description=self._get_json_description(source_type),
+                    ),
+                )
+            ),
+            after_validators=[bounds_validator] if bounds_validator is not None else [],
         )
 
     def _get_json_description(self, source_type: type[np.generic]) -> str:
@@ -153,23 +141,30 @@ class ScalarAdapter:
 _NUMERIC_KINDS: frozenset[str] = frozenset("uifc")  # uint, int, float, complex
 
 
-def _np_json_schema(kind: str) -> CoreSchema:
+def _np_json_schema(kind: str, *, description: str) -> CoreSchema:
     """Return the pydantic-core JSON input schema for a numpy scalar kind.
 
     Parameters
     ----------
     kind
         The single-character numpy dtype kind string (e.g. ``'f'``, ``'i'``).
+    description
+        Description to add to the JSON schema
 
     Returns
     -------
     CoreSchema
         A ``pydantic_core`` schema for the expected JSON payload.
     """
+    metadata = {
+        "pydantic_js_functions": [lambda c, h: h(c) | {"description": description}]
+    }
+
     if kind == "b":
         # np.bool_ - accept JSON bool or 0/1
         return core_schema.union_schema(
-            [core_schema.bool_schema(), core_schema.int_schema(ge=0, le=1)]
+            [core_schema.bool_schema(), core_schema.int_schema(ge=0, le=1)],
+            metadata=metadata,
         )
     if kind in _NUMERIC_KINDS:
         return core_schema.union_schema(
@@ -177,10 +172,11 @@ def _np_json_schema(kind: str) -> CoreSchema:
                 core_schema.float_schema(),
                 core_schema.int_schema(),
                 core_schema.str_schema(),
-            ]
+            ],
+            metadata=metadata,
         )
     # Fallback - accept any JSON value and let numpy decide
-    return core_schema.any_schema()
+    return core_schema.any_schema(metadata=metadata)
 
 
 def _build_before_validator(
@@ -198,10 +194,9 @@ def _build_before_validator(
     Callable[[Any], Any]
         A function that returns a validated numpy scalar.
     """
+    import numpy as np
 
     def _validate(value: ty.Any) -> ty.Any:
-        import numpy as np
-
         if isinstance(value, scalar_type):
             return value
         if isinstance(value, np.generic):

--- a/src/scientific_pydantic/numpy/scalar_adapter.py
+++ b/src/scientific_pydantic/numpy/scalar_adapter.py
@@ -1,0 +1,315 @@
+"""Pydantic adapters for numpy scalar types."""
+
+from __future__ import annotations
+
+import typing as ty
+
+from pydantic import PydanticSchemaGenerationError
+from pydantic_core import PydanticCustomError, core_schema
+
+from scientific_pydantic.schema import Encoding, make_core_schema
+
+if ty.TYPE_CHECKING:
+    import numpy as np
+    from pydantic import GetCoreSchemaHandler
+    from pydantic_core.core_schema import CoreSchema
+
+
+class ScalarAdapter:
+    """Pydantic adapter for NumPy scalar types.
+
+    Supports all numeric NumPy scalar kinds: signed/unsigned integers,
+    floating-point, complex, and boolean.
+
+    Validation Options
+    ------------------
+    1. Matching numpy scalar type - identity pass-through.
+    2. Any other numpy scalar - cast via the target type's constructor.
+    3. Python ``int``, ``float``, ``bool``, ``str`` - converted via the
+       target type's constructor.
+
+    JSON Serialization
+    ------------------
+    Scalars are serialized to JSON-safe Python primitives:
+
+    - ``np.bool_``: ``bool``
+    - ``np.integer`` subtypes: ``int``
+    - ``np.floating`` subtypes: ``float``
+    - ``np.complexfloating`` subtypes: ``str`` (e.g. ``"1+2j"``)
+
+    Parameters
+    ----------
+    gt
+        If given, validated values must be strictly greater than this.
+    ge
+        If given, validated values must be greater than or equal to this.
+    lt
+        If given, validated values must be strictly less than this.
+    le
+        If given, validated values must be less than or equal to this.
+    encoding
+        A custom [`Encoding`][scientific_pydantic.Encoding] to override the
+        default serialization/deserialization behaviour entirely.
+
+    Examples
+    --------
+    >>> from typing import Annotated
+    >>> import numpy as np
+    >>> import pydantic
+    >>> from scientific_pydantic.numpy import (
+    ...     ScalarAdapter,
+    ... )  # doctest: +NORMALIZE_WHITESPACE
+    <BLANKLINE>
+    >>> class Model(pydantic.BaseModel):
+    ...     prob: Annotated[np.float64, ScalarAdapter(ge=0.0, le=1.0)]
+    ...     n: Annotated[np.uint16, ScalarAdapter()]  # doctest: +NORMALIZE_WHITESPACE
+    <BLANKLINE>
+    >>> Model(prob=0.5, n=42)
+    Model(prob=np.float64(0.5), n=np.uint16(42))
+    >>> Model(prob="0.25", n="7")
+    Model(prob=np.float64(0.25), n=np.uint16(7))
+    """
+
+    def __init__(
+        self,
+        *,
+        gt: float | np.generic | None = None,
+        ge: float | np.generic | None = None,
+        lt: float | np.generic | None = None,
+        le: float | np.generic | None = None,
+        encoding: Encoding | None = None,
+    ) -> None:
+        self._gt = gt
+        self._ge = ge
+        self._lt = lt
+        self._le = le
+        self._encoding = encoding
+
+    def __get_pydantic_core_schema__(
+        self,
+        source_type: ty.Any,
+        _handler: GetCoreSchemaHandler,
+    ) -> CoreSchema:
+        """Build the pydantic-core schema for this numpy scalar type."""
+        import numpy as np
+
+        if not isinstance(source_type, type) or not issubclass(
+            source_type, (np.bool_, np.integer, np.inexact)
+        ):
+            msg = f"Source type {source_type} was not a supported NumPy scalar type"
+            raise PydanticSchemaGenerationError(msg)
+
+        kind: str = np.dtype(source_type).kind
+
+        before_validator = _build_before_validator(source_type)
+        bounds_validator = _build_bounds_validator(
+            source_type, gt=self._gt, ge=self._ge, lt=self._lt, le=self._le
+        )
+        after_validators: list[ty.Callable[[ty.Any], ty.Any]] = (
+            [bounds_validator] if bounds_validator is not None else []
+        )
+
+        # Insert the custom description
+        desc = self._get_json_description(source_type)
+        json_schema = _np_json_schema(kind)
+        json_schema["metadata"] = {
+            "pydantic_js_functions": [lambda c, h: h(c) | {"description": desc}]
+        }
+
+        encoding = (
+            self._encoding
+            if self._encoding is not None
+            else Encoding(
+                serializer=_serializer,
+                before_validator=before_validator,
+                json_schema=json_schema,
+            )
+        )
+
+        return make_core_schema(
+            source_type,
+            encoding=encoding,
+            after_validators=after_validators,
+        )
+
+    def _get_json_description(self, source_type: type[np.generic]) -> str:
+        """Get the description for the JSON schema"""
+        import numpy as np
+
+        dtype = np.dtype(source_type)
+        parts = [f"NumPy scalar: {dtype}"]
+        if self._gt is not None:
+            parts.append(f"value > {self._gt}")
+        if self._ge is not None:
+            parts.append(f"value >= {self._ge}")
+        if self._lt is not None:
+            parts.append(f"value < {self._lt}")
+        if self._le is not None:
+            parts.append(f"value <= {self._le}")
+        return ", ".join(parts)
+
+
+# Numpy scalar kind characters that map to a JSON number schema.
+_NUMERIC_KINDS: frozenset[str] = frozenset("uifc")  # uint, int, float, complex
+
+
+def _np_json_schema(kind: str) -> CoreSchema:
+    """Return the pydantic-core JSON input schema for a numpy scalar kind.
+
+    Parameters
+    ----------
+    kind
+        The single-character numpy dtype kind string (e.g. ``'f'``, ``'i'``).
+
+    Returns
+    -------
+    CoreSchema
+        A ``pydantic_core`` schema for the expected JSON payload.
+    """
+    if kind == "b":
+        # np.bool_ - accept JSON bool or 0/1
+        return core_schema.union_schema(
+            [core_schema.bool_schema(), core_schema.int_schema(ge=0, le=1)]
+        )
+    if kind in _NUMERIC_KINDS:
+        return core_schema.union_schema(
+            [
+                core_schema.float_schema(),
+                core_schema.int_schema(),
+                core_schema.str_schema(),
+            ]
+        )
+    # Fallback - accept any JSON value and let numpy decide
+    return core_schema.any_schema()
+
+
+def _build_before_validator(
+    scalar_type: type[np.generic],
+) -> ty.Callable[[ty.Any], ty.Any]:
+    """Return a before-validator that coerces *value* to *scalar_type*.
+
+    Parameters
+    ----------
+    scalar_type
+        A concrete numpy scalar type, e.g. ``np.float32``.
+
+    Returns
+    -------
+    Callable[[Any], Any]
+        A function that returns a validated numpy scalar.
+    """
+
+    def _validate(value: ty.Any) -> ty.Any:
+        import numpy as np
+
+        if isinstance(value, scalar_type):
+            return value
+        if isinstance(value, np.generic):
+            # Allow casting from other numpy scalar kinds
+            try:
+                return scalar_type(value)
+            except (ValueError, TypeError, OverflowError) as e:
+                err_t = "numpy_scalar_cast"
+                msg = "Cannot cast {src} to {dst}: {e}"
+                raise PydanticCustomError(
+                    err_t,
+                    msg,
+                    {"src": type(value).__name__, "dst": scalar_type.__name__, "e": e},
+                ) from e
+        # Accept Python scalars and strings
+        try:
+            return scalar_type(value)
+        except (TypeError, ValueError, OverflowError) as e:
+            err_t = "numpy_scalar_invalid"
+            msg = "Cannot convert {v!r} to {dst}: {e}"
+            raise PydanticCustomError(
+                err_t, msg, {"v": value, "dst": scalar_type.__name__, "e": e}
+            ) from e
+
+    return _validate
+
+
+def _build_bounds_validator(
+    scalar_type: type[np.generic],
+    *,
+    gt: float | np.generic | None,
+    ge: float | np.generic | None,
+    lt: float | np.generic | None,
+    le: float | np.generic | None,
+) -> ty.Callable[[ty.Any], ty.Any] | None:
+    """Return an after-validator enforcing numeric bounds, or *None* if unconstrained.
+
+    Parameters
+    ----------
+    scalar_type : type
+        The target numpy scalar type (used in error messages).
+    gt : float or None
+        Exclusive lower bound.
+    ge : float or None
+        Inclusive lower bound.
+    lt : float or None
+        Exclusive upper bound.
+    le : float or None
+        Inclusive upper bound.
+
+    Returns
+    -------
+    Callable or None
+        Validator function, or ``None`` when no bounds are specified.
+    """
+    if gt is None and ge is None and lt is None and le is None:
+        return None
+
+    def _check(value: ty.Any) -> ty.Any:
+        if gt is not None and not value > gt:
+            err_t = "numpy_scalar_gt"
+            msg = "{name} value {v} must be > {bound}"
+            raise PydanticCustomError(
+                err_t, msg, {"name": scalar_type.__name__, "v": value, "bound": gt}
+            )
+        if ge is not None and not value >= ge:
+            err_t = "numpy_scalar_ge"
+            msg = "{name} value {v} must be >= {bound}"
+            raise PydanticCustomError(
+                err_t, msg, {"name": scalar_type.__name__, "v": value, "bound": ge}
+            )
+        if lt is not None and not value < lt:
+            err_t = "numpy_scalar_lt"
+            msg = "{name} value {v} must be < {bound}"
+            raise PydanticCustomError(
+                err_t, msg, {"name": scalar_type.__name__, "v": value, "bound": lt}
+            )
+        if le is not None and not value <= le:
+            err_t = "numpy_scalar_le"
+            msg = "{name} value {v} must be <= {bound}"
+            raise PydanticCustomError(
+                err_t, msg, {"name": scalar_type.__name__, "v": value, "bound": le}
+            )
+        return value
+
+    return _check
+
+
+def _serializer(value: ty.Any) -> float | int | bool | str:
+    """Serialize a numpy scalar to a JSON-safe Python primitive.
+
+    Parameters
+    ----------
+    value : numpy scalar
+        The validated numpy scalar to serialize.
+
+    Returns
+    -------
+    float or int or bool or str
+        The JSON-safe representation.
+    """
+    import numpy as np
+
+    if isinstance(value, np.bool_):
+        return bool(value)
+    if isinstance(value, np.complexfloating):
+        # JSON has no native complex; serialize as "a+bj" string
+        return str(complex(value))
+    if isinstance(value, np.integer):
+        return int(value)
+    return float(value)

--- a/tests/numpy/test_scalars.py
+++ b/tests/numpy/test_scalars.py
@@ -1,0 +1,340 @@
+"""Tests for scientific_pydantic.numpy.scalar_adapter."""
+
+from __future__ import annotations
+
+import json
+import typing as ty
+
+import numpy as np
+import pydantic
+import pytest
+
+from scientific_pydantic.numpy import ScalarAdapter
+
+# ---------------------------------------------------------------------------
+# Helpers / fixtures
+# ---------------------------------------------------------------------------
+
+
+_INT_TYPES: list[type] = [np.int8, np.int16, np.int32, np.int64]
+_UINT_TYPES: list[type] = [np.uint8, np.uint16, np.uint32, np.uint64]
+_FLOAT_TYPES: list[type] = [np.float16, np.float32, np.float64]
+_COMPLEX_TYPES: list[type] = [np.complex64, np.complex128]
+
+
+def _model(scalar_type: type, **adapter_kwargs: ty.Any) -> type[pydantic.BaseModel]:
+    """Return a single-field pydantic model annotated with *scalar_type*."""
+    adapter = ScalarAdapter(**adapter_kwargs)
+
+    class _M(pydantic.BaseModel):
+        v: ty.Annotated[scalar_type, adapter]  # type: ignore[valid-type]
+
+    return _M
+
+
+# ---------------------------------------------------------------------------
+# Identity / type preservation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("scalar_type", "value"),
+    [
+        pytest.param(np.int8, np.int8(42), id="int8-identity"),
+        pytest.param(np.int32, np.int32(-7), id="int32-identity"),
+        pytest.param(np.uint16, np.uint16(255), id="uint16-identity"),
+        pytest.param(np.float32, np.float32(3.14), id="float32-identity"),
+        pytest.param(np.float64, np.float64(-1.0), id="float64-identity"),
+        pytest.param(np.complex128, np.complex128(1 + 2j), id="complex128-identity"),
+        pytest.param(np.bool_, np.True_, id="bool-identity"),
+    ],
+)
+def test_identity_passthrough(scalar_type: type, value: ty.Any) -> None:
+    """Already-correct scalars are returned unchanged."""
+
+    class Model(pydantic.BaseModel):
+        v: ty.Annotated[scalar_type, ScalarAdapter()]
+
+    m = Model(v=value)
+    assert isinstance(m.v, scalar_type)
+    assert m.v == value
+
+
+# ---------------------------------------------------------------------------
+# Python scalar coercion
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("scalar_type", "python_value"),
+    [
+        pytest.param(np.int16, 100, id="int16-from-int"),
+        pytest.param(np.uint8, 200, id="uint8-from-int"),
+        pytest.param(np.float32, 2.718, id="float32-from-float"),
+        pytest.param(np.float64, 0, id="float64-from-int"),
+        pytest.param(np.bool_, True, id="bool-from-bool"),
+        pytest.param(np.bool_, 0, id="bool-from-zero"),
+    ],
+)
+def test_python_scalar_coercion(scalar_type: type, python_value: ty.Any) -> None:
+    """Python scalars are coerced to the target numpy type."""
+
+    class Model(pydantic.BaseModel):
+        v: ty.Annotated[scalar_type, ScalarAdapter()]
+
+    m = Model(v=python_value)
+    assert isinstance(m.v, scalar_type)
+
+
+# ---------------------------------------------------------------------------
+# String coercion
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("scalar_type", "str_value", "expected"),
+    [
+        pytest.param(np.float32, "3.14", np.float32(3.14), id="float32-from-str"),
+        pytest.param(np.int64, "-99", np.int64(-99), id="int64-from-str"),
+        pytest.param(np.uint32, "42", np.uint32(42), id="uint32-from-str"),
+    ],
+)
+def test_string_coercion(scalar_type: type, str_value: str, expected: ty.Any) -> None:
+    """String inputs are parsed and cast to the target numpy scalar."""
+
+    class Model(pydantic.BaseModel):
+        v: ty.Annotated[scalar_type, ScalarAdapter()]
+
+    m = Model(v=str_value)
+    assert isinstance(m.v, scalar_type)
+    np.testing.assert_allclose(float(m.v), float(expected))
+
+
+# ---------------------------------------------------------------------------
+# Cross-kind numpy casting
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("target_type", "input_scalar"),
+    [
+        pytest.param(np.float64, np.int32(5), id="float64-from-int32"),
+        pytest.param(np.int32, np.float32(7.0), id="int32-from-float32"),
+        pytest.param(np.uint8, np.int64(200), id="uint8-from-int64"),
+    ],
+)
+def test_cross_kind_cast(target_type: type, input_scalar: np.generic) -> None:
+    """Numpy scalars of different kinds are cast to the target type."""
+
+    class Model(pydantic.BaseModel):
+        v: ty.Annotated[target_type, ScalarAdapter()]
+
+    m = Model(v=input_scalar)
+    assert isinstance(m.v, target_type)
+    assert m.v == target_type(input_scalar)
+
+
+# ---------------------------------------------------------------------------
+# Bounds validation - accepted values
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("scalar_type", "kwargs", "value"),
+    [
+        pytest.param(np.float64, {"ge": 0.0}, 0.0, id="float64-ge=0-boundary"),
+        pytest.param(np.float64, {"ge": 0.0}, 1.5, id="float64-ge=0-above"),
+        pytest.param(np.float64, {"gt": 0.0}, 0.001, id="float64-gt=0"),
+        pytest.param(np.float32, {"le": 1.0}, 1.0, id="float32-le=1-boundary"),
+        pytest.param(np.float32, {"lt": 1.0}, 0.999, id="float32-lt=1"),
+        pytest.param(np.int32, {"ge": -10, "le": 10}, 0, id="int32-bounded-middle"),
+        pytest.param(np.uint8, {"ge": 0, "le": 255}, 255, id="uint8-max"),
+    ],
+)
+def test_bounds_accepted(
+    scalar_type: type, kwargs: dict[str, float], value: ty.Any
+) -> None:
+    """Values within the specified bounds are accepted."""
+
+    class Model(pydantic.BaseModel):
+        v: ty.Annotated[scalar_type, ScalarAdapter(**kwargs)]
+
+    m = Model(v=value)
+    assert isinstance(m.v, scalar_type)
+
+
+# ---------------------------------------------------------------------------
+# Bounds validation - rejected values
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("scalar_type", "kwargs", "bad_value"),
+    [
+        pytest.param(np.float64, {"ge": 0.0}, -0.001, id="float64-ge=0-below"),
+        pytest.param(np.float64, {"gt": 0.0}, 0.0, id="float64-gt=0-at-zero"),
+        pytest.param(np.float32, {"le": 1.0}, 1.001, id="float32-le=1-above"),
+        pytest.param(np.float32, {"lt": 1.0}, 1.0, id="float32-lt=1-at-bound"),
+        pytest.param(np.int32, {"ge": -10, "le": 10}, 11, id="int32-exceeds-upper"),
+        pytest.param(np.int32, {"ge": -10, "le": 10}, -11, id="int32-below-lower"),
+    ],
+)
+def test_bounds_rejected(
+    scalar_type: type, kwargs: dict[str, float], bad_value: ty.Any
+) -> None:
+    """Values outside the specified bounds raise ValidationError."""
+
+    class Model(pydantic.BaseModel):
+        v: ty.Annotated[scalar_type, ScalarAdapter(**kwargs)]
+
+    with pytest.raises(pydantic.ValidationError):
+        Model(v=bad_value)
+
+
+# ---------------------------------------------------------------------------
+# Invalid inputs
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("scalar_type", "bad_value"),
+    [
+        pytest.param(np.float32, "not-a-number", id="float32-bad-str"),
+        pytest.param(np.int16, [1, 2], id="int16-from-list"),
+        pytest.param(np.uint8, -1, id="uint8-overflow-neg"),
+        pytest.param(np.int8, 200, id="int8-overflow-pos"),
+    ],
+)
+def test_invalid_inputs_rejected(scalar_type: type, bad_value: ty.Any) -> None:
+    """Clearly invalid inputs raise ValidationError."""
+
+    class Model(pydantic.BaseModel):
+        v: ty.Annotated[scalar_type, ScalarAdapter()]
+
+    with pytest.raises(pydantic.ValidationError):
+        Model(v=bad_value)
+
+
+# ---------------------------------------------------------------------------
+# JSON round-trip
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("scalar_type", "value"),
+    [
+        pytest.param(np.int32, np.int32(7), id="int32-roundtrip"),
+        pytest.param(np.uint8, np.uint8(255), id="uint8-roundtrip"),
+        pytest.param(np.float32, np.float32(1.5), id="float32-roundtrip"),
+        pytest.param(np.float64, np.float64(-2.71828), id="float64-roundtrip"),
+        pytest.param(np.bool_, np.False_, id="bool-roundtrip"),
+    ],
+)
+def test_json_roundtrip(scalar_type: type, value: ty.Any) -> None:
+    """model_dump(mode='json') and model_validate_json produce equivalent models."""
+
+    class Model(pydantic.BaseModel):
+        v: ty.Annotated[scalar_type, ScalarAdapter()]
+
+    m = Model(v=value)
+    json_str = m.model_dump_json()
+    # Ensure the serialised payload is valid JSON
+    payload = json.loads(json_str)
+    assert "v" in payload
+
+    # Re-validate from JSON
+    m2 = Model.model_validate_json(json_str)
+    assert isinstance(m2.v, scalar_type)
+    np.testing.assert_allclose(float(m2.v), float(value), rtol=1e-4)
+
+
+def test_complex_json_roundtrip() -> None:
+    """Complex scalars serialise to a string and round-trip cleanly."""
+
+    class Model(pydantic.BaseModel):
+        v: ty.Annotated[np.complex128, ScalarAdapter()]
+
+    val = np.complex128(3.0 + 4.0j)
+    m = Model(v=val)
+    json_str = m.model_dump_json()
+    payload = json.loads(json_str)
+    # The serialised form must be a string representing the complex number
+    assert isinstance(payload["v"], str)
+    m2 = Model.model_validate_json(json_str)
+    assert isinstance(m2.v, np.complex128)
+    assert np.isclose(m2.v, val)
+
+
+# ---------------------------------------------------------------------------
+# JSON schema generation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("scalar_type", "kwargs", "expected_fragments"),
+    [
+        pytest.param(np.float32, {}, ["float32"], id="float32-no-bounds"),
+        pytest.param(
+            np.float64,
+            {"ge": 0.0, "le": 1.0},
+            ["float64", ">= 0.0", "<= 1.0"],
+            id="float64-with-bounds",
+        ),
+        pytest.param(
+            np.int32,
+            {"gt": -5, "lt": 5},
+            ["int32", "> -5", "< 5"],
+            id="int32-strict-bounds",
+        ),
+    ],
+)
+def test_json_schema_description(
+    scalar_type: type,
+    kwargs: dict[str, float],
+    expected_fragments: list[str],
+) -> None:
+    """The generated JSON schema description includes dtype and constraint info."""
+
+    class Model(pydantic.BaseModel):
+        v: ty.Annotated[scalar_type, ScalarAdapter(**kwargs)]
+
+    schema = Model.model_json_schema()
+    desc: str = schema.get("properties", {}).get("v", {}).get("description", "")
+    for fragment in expected_fragments:
+        assert fragment in desc, f"Expected {fragment} in description: {desc}"
+
+
+# ---------------------------------------------------------------------------
+# Error paths
+# ---------------------------------------------------------------------------
+
+
+def test_bad_base_type() -> None:
+    """Test using the adapter on an invalid base type"""
+    with pytest.raises(
+        pydantic.PydanticSchemaGenerationError,
+        match="was not a supported NumPy scalar type",
+    ):
+
+        class Model(pydantic.BaseModel):
+            f: ty.Annotated[bool, ScalarAdapter()]
+
+
+@pytest.mark.parametrize(
+    ("source_type", "value"),
+    [
+        pytest.param(np.uint16, np.bytes_(b"abc"), id="bytes-to-u16"),
+        pytest.param(np.int16, np.str_("hi"), id="str-to-i16"),
+    ],
+)
+def test_cast_overflow(
+    source_type: type,
+    value: np.generic,
+) -> None:
+    """Test overflow from numpy type casting"""
+
+    class Model(pydantic.BaseModel):
+        v: ty.Annotated[source_type, ScalarAdapter()]
+
+    with pytest.raises(pydantic.ValidationError, match="numpy_scalar_cast"):
+        Model(v=value)


### PR DESCRIPTION
This PR adds support for NumPy numeric scalar types via `ScalarAdapter`