### PR TITLE
Add support for constrained int's on RangeAdapter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "scientific_pydantic"
-version = "0.4.0"
+version = "0.5.0a1"
 description = "Pydantic adapters for common scientific types"
 readme = "README.md"
 license = "MIT"

--- a/src/scientific_pydantic/common_range_slice.py
+++ b/src/scientific_pydantic/common_range_slice.py
@@ -1,0 +1,79 @@
+"""Common functionality between slice and range"""
+
+import typing as ty
+from collections.abc import Hashable
+
+import pydantic
+from pydantic_core import InitErrorDetails, PydanticCustomError
+
+UNSET = object()
+
+T = ty.TypeVar("T", range, slice)
+
+
+class StartStopStepAdapters:
+    """Manages type adapters for the start/stop/step fields in range/slice"""
+
+    def __init__(
+        self,
+        default_type: Hashable = ty.Any,
+        *,
+        start_type: Hashable = UNSET,
+        stop_type: Hashable = UNSET,
+        step_type: Hashable = UNSET,
+    ) -> None:
+        adapters = {
+            t: pydantic.TypeAdapter(t)
+            for t in {default_type, start_type, stop_type, step_type}
+            if t is not UNSET
+        }
+        default_adapter = adapters[default_type]
+        self.start_adapter = (
+            adapters[start_type] if start_type is not UNSET else default_adapter
+        )
+        self.stop_adapter = (
+            adapters[stop_type] if stop_type is not UNSET else default_adapter
+        )
+        self.step_adapter = (
+            adapters[step_type] if step_type is not UNSET else default_adapter
+        )
+
+    def after_validator(self, val: T) -> T:
+        """Validate the fields w.r.t. to type adapters"""
+        try:
+            start = self.start_adapter.validate_python(val.start)
+        except pydantic.ValidationError as e:
+            raise _prefix_validation_error(e, "start") from None
+        try:
+            stop = self.stop_adapter.validate_python(val.stop)
+        except pydantic.ValidationError as e:
+            raise _prefix_validation_error(e, "stop") from None
+        try:
+            step = self.step_adapter.validate_python(val.step)
+        except pydantic.ValidationError as e:
+            raise _prefix_validation_error(e, "step") from None
+        return type(val)(start, stop, step)
+
+
+def _prefix_validation_error(
+    exc: pydantic.ValidationError,
+    field: str,
+) -> pydantic.ValidationError:
+    """Rebuild a ValidationError with `field` prepended to every error path."""
+    details: list[InitErrorDetails] = []
+    for error in exc.errors(include_url=False):
+        err_t = error["type"]
+        msg = error["msg"]
+        details.append(
+            InitErrorDetails(
+                # The message is rendered at this point, so these aren't literal
+                # string anymore. It works at runtime.
+                type=PydanticCustomError(err_t, msg),  # type: ignore[bad-argument-type]
+                loc=(field, *error["loc"]),
+                input=error["input"],
+            )
+        )
+    return pydantic.ValidationError.from_exception_data(
+        title=exc.title,
+        line_errors=details,
+    )

--- a/src/scientific_pydantic/range.py
+++ b/src/scientific_pydantic/range.py
@@ -1,11 +1,13 @@
 """Adaptor for range"""
 
 import typing as ty
+from collections.abc import Hashable
 
 import pydantic
 from pydantic.json_schema import JsonSchemaValue
 from pydantic_core import PydanticCustomError, core_schema
 
+from .common_range_slice import UNSET, StartStopStepAdapters
 from .schema import Encoding, make_core_schema
 from .slice_syntax import (
     SliceSyntaxError,
@@ -17,11 +19,30 @@ from .slice_syntax import (
 class RangeAdapter:
     """Pydantic adapter for Python `range` using slice syntax.
 
+    Currently, only `int` slices are supported.
+
     Validation Options
     ------------------
     1. `range` - Identity
     2. `str` - A slice-like syntax (`[start:]stop[:step]`) is used. This
         representation is also used for the JSON encoding of range.
+
+    Parameters
+    ----------
+    default_type
+        The default type annotation for all 3 elements of the range. This must
+        either be int or an annotated int.
+    start_type
+        If given, overrides `default_type` as the type annotation for the start
+        of the range.
+    stop_type
+        If given, overrides `default_type` as the type annotation for the stop
+        of the range.
+    step_type
+        If given, overrides `default_type` as the type annotation for the step
+        of the range.
+    encoding
+        A custom encoding for this type
 
     Examples
     --------
@@ -38,22 +59,52 @@ class RangeAdapter:
     Model(field=range(12, 25, 2))
     """
 
-    @classmethod
+    def __init__(
+        self,
+        default_type: Hashable = int,
+        *,
+        start_type: Hashable = UNSET,
+        stop_type: Hashable = UNSET,
+        step_type: Hashable = UNSET,
+        encoding: Encoding | None = None,
+    ) -> None:
+        for t, label in (
+            (default_type, "default_type"),
+            (start_type, "start_type"),
+            (stop_type, "stop_type"),
+            (step_type, "step_type"),
+        ):
+            if (
+                t is UNSET
+                or t is int  # type: ignore[unnecessary-comparison]
+                or (ty.get_origin(t) is ty.Annotated and ty.get_args(t)[0] is int)
+            ):
+                continue
+
+            msg = (
+                f"RangeAdapter: {label} was {t}, but only int's or annotated "
+                "int's are currently supported"
+            )
+            raise ValueError(msg)
+
+        self._adapters = StartStopStepAdapters(
+            default_type,
+            start_type=start_type,
+            stop_type=stop_type,
+            step_type=step_type,
+        )
+        self._encoding = encoding if encoding is not None else self._default_encoding()
+
     def __get_pydantic_core_schema__(
-        cls,
+        self,
         _source_type: ty.Any,
         _handler: pydantic.GetCoreSchemaHandler,
     ) -> core_schema.CoreSchema:
         """Get the pydantic schema for this type"""
         return make_core_schema(
             range,
-            encoding=Encoding(
-                serializer=_serialize,
-                before_validator=_validate,
-                json_schema=core_schema.str_schema(
-                    pattern=r"^\s*-?\d+\s*:\s*-?\d+\s*(?::\s*-?\d+\s*)?$"
-                ),
-            ),
+            encoding=self._encoding,
+            after_validators=[self._adapters.after_validator],
         )
 
     @classmethod
@@ -67,6 +118,15 @@ class RangeAdapter:
         schema["description"] = "Python range syntax: start:stop[:step]"
         return schema
 
+    def _default_encoding(self) -> Encoding[range]:
+        return Encoding(
+            serializer=_serialize,
+            before_validator=_validate,
+            json_schema=core_schema.str_schema(
+                pattern=r"^\s*-?\d+\s*:\s*-?\d+\s*(?::\s*-?\d+\s*)?$"
+            ),
+        )
+
 
 def _validate(value: ty.Any) -> range:
     if isinstance(value, range):
@@ -79,6 +139,7 @@ def _validate(value: ty.Any) -> range:
                 converter=int,
                 require_start=False,
                 require_stop=True,
+                dest_type=range,
             )
         except SliceSyntaxError as e:
             err_t = "range_syntax_error"

--- a/src/scientific_pydantic/range.py
+++ b/src/scientific_pydantic/range.py
@@ -1,6 +1,7 @@
 """Adaptor for range"""
 
 import typing as ty
+import warnings
 from collections.abc import Hashable
 
 import pydantic
@@ -19,7 +20,8 @@ from .slice_syntax import (
 class RangeAdapter:
     """Pydantic adapter for Python `range` using slice syntax.
 
-    Currently, only `int` slices are supported.
+    Currently, only ranges with `int` fields are supported. Generic elements
+    that implement `__index__()` are not supported.
 
     Validation Options
     ------------------
@@ -82,8 +84,8 @@ class RangeAdapter:
                 continue
 
             msg = (
-                f"RangeAdapter: {label} was {t}, but only int's or annotated "
-                "int's are currently supported"
+                f"RangeAdapter: {label} was {t}, but only int or an annotated "
+                "int is currently supported"
             )
             raise ValueError(msg)
 
@@ -93,18 +95,36 @@ class RangeAdapter:
             stop_type=stop_type,
             step_type=step_type,
         )
-        self._encoding = encoding if encoding is not None else self._default_encoding()
+        self._encoding = encoding if encoding is not None else _default_encoding()
 
     def __get_pydantic_core_schema__(
         self,
-        _source_type: ty.Any,
-        _handler: pydantic.GetCoreSchemaHandler,
+        source_type: ty.Any,
+        handler: pydantic.GetCoreSchemaHandler | None = None,
     ) -> core_schema.CoreSchema:
         """Get the pydantic schema for this type"""
+        if handler is None:
+            msg = (
+                "Using RangeAdapter as a class annotation is deprecated. "
+                "Instead, use a RangeAdapter instance via RangeAdapter(). "
+                "This functionality will be removed in v0.6.0."
+            )
+            warnings.warn(msg, DeprecationWarning, stacklevel=2)
+            source_type = self
+            encoding = _default_encoding()
+            after_validators = []
+        else:
+            encoding = self._encoding
+            after_validators = [self._adapters.after_validator]
+
+        if source_type is not range:
+            msg = f"RangeAdapter must be used with range, not {source_type}"
+            raise pydantic.PydanticSchemaGenerationError(msg)
+
         return make_core_schema(
             range,
-            encoding=self._encoding,
-            after_validators=[self._adapters.after_validator],
+            encoding=encoding,
+            after_validators=after_validators,
         )
 
     @classmethod
@@ -117,15 +137,6 @@ class RangeAdapter:
         schema = handler(core_schema)
         schema["description"] = "Python range syntax: start:stop[:step]"
         return schema
-
-    def _default_encoding(self) -> Encoding[range]:
-        return Encoding(
-            serializer=_serialize,
-            before_validator=_validate,
-            json_schema=core_schema.str_schema(
-                pattern=r"^\s*-?\d+\s*:\s*-?\d+\s*(?::\s*-?\d+\s*)?$"
-            ),
-        )
 
 
 def _validate(value: ty.Any) -> range:
@@ -160,3 +171,13 @@ def _validate(value: ty.Any) -> range:
 def _serialize(value: range) -> str:
     step = None if value.step == 1 else value.step
     return format_slice_syntax(value.start, value.stop, step)
+
+
+def _default_encoding() -> Encoding[range]:
+    return Encoding(
+        serializer=_serialize,
+        before_validator=_validate,
+        json_schema=core_schema.str_schema(
+            pattern=r"^\s*-?\d+\s*:\s*-?\d+\s*(?::\s*-?\d+\s*)?$"
+        ),
+    )

--- a/src/scientific_pydantic/slice.py
+++ b/src/scientific_pydantic/slice.py
@@ -5,16 +5,15 @@ import typing as ty
 from collections.abc import Hashable, Mapping, Sequence
 
 import pydantic
-from pydantic_core import InitErrorDetails, PydanticCustomError, core_schema
+from pydantic_core import PydanticCustomError, core_schema
 
+from .common_range_slice import UNSET, StartStopStepAdapters
 from .schema import Encoding, make_core_schema
 from .slice_syntax import (
     SliceSyntaxError,
     format_slice_syntax,
     parse_slice_syntax,
 )
-
-UNSET = object()
 
 
 class SliceAdapter:
@@ -44,7 +43,7 @@ class SliceAdapter:
     ----------
     default_type
         The default type annotation for all 3 elements of the slice. This should
-        normally include `None` unless all 3 elements are always required..
+        normally include `None` unless all 3 elements are always required.
     start_type
         If given, overrides `default_type` as the type annotation for the start
         of the slice.
@@ -85,20 +84,11 @@ class SliceAdapter:
         step_type: Hashable = UNSET,
         encoding: Encoding | None = None,
     ) -> None:
-        adapters = {
-            t: pydantic.TypeAdapter(t)
-            for t in {default_type, start_type, stop_type, step_type}
-            if t is not UNSET
-        }
-        self._default_adapter = adapters[default_type]
-        self._start_adapter = (
-            adapters[start_type] if start_type is not UNSET else self._default_adapter
-        )
-        self._stop_adapter = (
-            adapters[stop_type] if stop_type is not UNSET else self._default_adapter
-        )
-        self._step_adapter = (
-            adapters[step_type] if step_type is not UNSET else self._default_adapter
+        self._adapters = StartStopStepAdapters(
+            default_type,
+            start_type=start_type,
+            stop_type=stop_type,
+            step_type=step_type,
         )
         self._encoding = encoding if encoding is not None else self._default_encoding()
 
@@ -108,21 +98,6 @@ class SliceAdapter:
         _handler: pydantic.GetCoreSchemaHandler,
     ) -> core_schema.CoreSchema:
         """Get the pydantic schema for this type"""
-
-        def _validate(value: slice) -> slice:
-            try:
-                start = self._start_adapter.validate_python(value.start)
-            except pydantic.ValidationError as e:
-                raise _prefix_validation_error(e, "start") from None
-            try:
-                stop = self._stop_adapter.validate_python(value.stop)
-            except pydantic.ValidationError as e:
-                raise _prefix_validation_error(e, "stop") from None
-            try:
-                step = self._step_adapter.validate_python(value.step)
-            except pydantic.ValidationError as e:
-                raise _prefix_validation_error(e, "step") from None
-            return slice(start, stop, step)
 
         def _serialize(value: slice) -> str | dict[str, ty.Any]:
             if all(
@@ -140,7 +115,7 @@ class SliceAdapter:
         return make_core_schema(
             slice,
             encoding=self._encoding,
-            after_validators=[_validate],
+            after_validators=[self._adapters.after_validator],
         )
 
     def _default_encoding(self) -> Encoding[slice]:
@@ -166,21 +141,16 @@ class SliceAdapter:
                     core_schema.list_schema(min_length=1, max_length=3),
                     core_schema.typed_dict_schema(
                         {
-                            "start": core_schema.typed_dict_field(
-                                self._start_adapter.core_schema
-                                if self._start_adapter is not None
-                                else core_schema.any_schema(),
-                            ),
-                            "stop": core_schema.typed_dict_field(
-                                self._stop_adapter.core_schema
-                                if self._stop_adapter is not None
-                                else core_schema.any_schema(),
-                            ),
-                            "step": core_schema.typed_dict_field(
-                                self._step_adapter.core_schema
-                                if self._step_adapter is not None
-                                else core_schema.any_schema(),
-                            ),
+                            key: core_schema.typed_dict_field(
+                                adapter.core_schema
+                                if adapter is not None
+                                else core_schema.any_schema()
+                            )
+                            for key, adapter in (
+                                ("start", self._adapters.start_adapter),
+                                ("stop", self._adapters.stop_adapter),
+                                ("step", self._adapters.step_adapter),
+                            )
                         },
                         total=False,
                     ),
@@ -205,6 +175,7 @@ def _from_str(value: str) -> tuple[ty.Any, ty.Any, ty.Any]:
             converter=str,
             require_start=False,
             require_stop=True,
+            dest_type=slice,
         )
     except SliceSyntaxError as e:
         err_t = "slice_syntax_error"
@@ -239,30 +210,6 @@ def _validate_slice(value: ty.Any) -> slice:
             raise PydanticCustomError(err_t, msg, {"t": type(value).__name__})
 
     return slice(start, stop, step)
-
-
-def _prefix_validation_error(
-    exc: pydantic.ValidationError,
-    field: str,
-) -> pydantic.ValidationError:
-    """Rebuild a ValidationError with `field` prepended to every error path."""
-    details: list[InitErrorDetails] = []
-    for error in exc.errors(include_url=False):
-        err_t = error["type"]
-        msg = error["msg"]
-        details.append(
-            InitErrorDetails(
-                # The message is rendered at this point, so these aren't literal
-                # string anymore. It works at runtime.
-                type=PydanticCustomError(err_t, msg),  # type: ignore[bad-argument-type]
-                loc=(field, *error["loc"]),
-                input=error["input"],
-            )
-        )
-    return pydantic.ValidationError.from_exception_data(
-        title=exc.title,
-        line_errors=details,
-    )
 
 
 IntSliceAdapter = SliceAdapter(int | None)

--- a/src/scientific_pydantic/slice.py
+++ b/src/scientific_pydantic/slice.py
@@ -98,20 +98,6 @@ class SliceAdapter:
         _handler: pydantic.GetCoreSchemaHandler,
     ) -> core_schema.CoreSchema:
         """Get the pydantic schema for this type"""
-
-        def _serialize(value: slice) -> str | dict[str, ty.Any]:
-            if all(
-                x is None or isinstance(x, numbers.Number)
-                for x in (value.start, value.stop, value.step)
-            ):
-                return format_slice_syntax(value.start, value.stop, value.step)
-
-            return {
-                "start": value.start,
-                "stop": value.stop,
-                "step": value.step,
-            }
-
         return make_core_schema(
             slice,
             encoding=self._encoding,

--- a/src/scientific_pydantic/slice_syntax.py
+++ b/src/scientific_pydantic/slice_syntax.py
@@ -17,6 +17,7 @@ def parse_slice_syntax(
     converter: ty.Callable[[str], T],
     require_start: ty.Literal[True],
     require_stop: ty.Literal[True],
+    dest_type: type,
 ) -> tuple[T, T, T | None]: ...
 
 
@@ -27,6 +28,7 @@ def parse_slice_syntax(
     converter: ty.Callable[[str], T],
     require_start: ty.Literal[False],
     require_stop: ty.Literal[True],
+    dest_type: type,
 ) -> tuple[T | None, T, T | None]: ...
 
 
@@ -37,6 +39,7 @@ def parse_slice_syntax(
     converter: ty.Callable[[str], T],
     require_start: ty.Literal[False],
     require_stop: ty.Literal[False],
+    dest_type: type,
 ) -> tuple[T | None, T | None, T | None]: ...
 
 
@@ -47,6 +50,7 @@ def parse_slice_syntax(
     converter: ty.Callable[[str], T],
     require_start: ty.Literal[True],
     require_stop: ty.Literal[False],
+    dest_type: type,
 ) -> tuple[T, T | None, T | None]: ...
 
 
@@ -56,19 +60,22 @@ def parse_slice_syntax(
     converter: ty.Callable[[str], T],
     require_start: bool,
     require_stop: bool,
+    dest_type: type,
 ) -> tuple[T | None, T | None, T | None]:
     """Parse a Python-style slice string: [start]:[stop][:step].
 
     Parameters
     ----------
-    value : str
+    value
         Slice syntax string.
-    converter : Callable[[str], T]
+    converter
         Conversion function to use on each element if present
-    require_start : bool
+    require_start
         Whether start must be present and non-empty.
-    require_stop : bool
+    require_stop
         Whether stop must be present and non-empty.
+    dest_type
+        Destination type for the resulting tuple (only used in errors)
 
     Returns
     -------
@@ -78,7 +85,8 @@ def parse_slice_syntax(
     n_parts = len(parts)
     if not 2 <= n_parts <= 3:  # noqa: PLR2004
         msg = (
-            f"invalid slice syntax, expected 2-3 parts separated by :'s, got {n_parts}"
+            f"invalid {dest_type.__name__} syntax, expected 2-3 parts "
+            f"separated by :'s, got {n_parts}"
         )
         raise SliceSyntaxError(msg)
 
@@ -93,7 +101,7 @@ def parse_slice_syntax(
         stop = _parse(parts[1])
         step = _parse(parts[2]) if len(parts) == 3 else None  # noqa: PLR2004
     except (ValueError, TypeError) as exc:
-        msg = "invalid integer in slice string"
+        msg = f"invalid integer in {dest_type.__name__} string"
         raise SliceSyntaxError(msg) from exc
 
     if require_start and start is None:

--- a/tests/test_range.py
+++ b/tests/test_range.py
@@ -8,43 +8,145 @@ import pytest
 from scientific_pydantic import RangeAdapter
 
 
-class _Model(pydantic.BaseModel):
-    """Test model using RangeAdapter."""
-
-    r: RangeAdapter
-
-
 @pytest.mark.parametrize(
-    ("value", "expected"),
+    ("kwargs", "value", "expected"),
     [
-        pytest.param(range(5), range(5), id="range(5)"),
-        pytest.param(":5", range(5), id=":5"),
-        pytest.param(" : 5", range(5), id=" : 5"),
-        pytest.param("1:5", range(1, 5), id="1:5"),
-        pytest.param(" 1\t:\n5 : ", range(1, 5), id=" 1 : 5 : "),
-        pytest.param("1:10:2", range(1, 10, 2), id="1:10:2"),
+        pytest.param({}, range(5), range(5), id="range(5)"),
+        pytest.param({}, ":5", range(5), id=":5"),
+        pytest.param({}, " : 5", range(5), id=" : 5"),
+        pytest.param({}, "1:5", range(1, 5), id="1:5"),
+        pytest.param({}, " 1\t:\n5 : ", range(1, 5), id=" 1 : 5 : "),
+        pytest.param({}, "1:10:2", range(1, 10, 2), id="1:10:2"),
+        pytest.param(
+            {"default_type": pydantic.PositiveInt},
+            "1:10:2",
+            range(1, 10, 2),
+            id="pos-1:10:2",
+        ),
+        pytest.param(
+            {"step_type": pydantic.NegativeInt},
+            "1:10:-2",
+            range(1, 10, -12),
+            id="neg-step-1:10:-12",
+        ),
     ],
 )
-def test_range_validation(value: ty.Any, expected: range) -> None:
+def test_range_validation(
+    kwargs: dict[str, ty.Any], value: ty.Any, expected: range
+) -> None:
     """Valid inputs are converted to a range."""
-    model = _Model(r=value)
+
+    class Model(pydantic.BaseModel):
+        r: ty.Annotated[range, RangeAdapter(**kwargs)]
+
+    model = Model(r=value)
     assert model.r == expected
 
 
 @pytest.mark.parametrize(
-    "value",
+    ("kwargs", "value", "match"),
     [
-        pytest.param(123, id="invalid_range"),
-        pytest.param("5", id="5"),
-        pytest.param("random text", id="random text"),
-        pytest.param("random:text:with colons", id="non-ints"),
-        pytest.param("1:2:3:4", id="1:2:3:4"),
+        pytest.param(
+            {},
+            123,
+            "expected range or slice-syntax string, got int",
+            id="invalid_range",
+        ),
+        pytest.param(
+            {},
+            "5",
+            "invalid range syntax, expected 2-3 parts separated by :'s, got 1",
+            id="5",
+        ),
+        pytest.param(
+            {},
+            "random text",
+            "invalid range syntax, expected 2-3 parts separated by :'s, got 1",
+            id="random text",
+        ),
+        pytest.param(
+            {},
+            "random:text:with colons",
+            "invalid integer in range string",
+            id="non-ints",
+        ),
+        pytest.param(
+            {},
+            "1:2:3:4",
+            "invalid range syntax, expected 2-3 parts separated by :'s, got 4",
+            id="1:2:3:4",
+        ),
+        pytest.param(
+            {"default_type": pydantic.PositiveInt},
+            "-1:3",
+            r"(?s)r\.start.*Input should be greater than 0",
+            id="pos--1:3:1",
+        ),
+        pytest.param(
+            {"stop_type": pydantic.PositiveInt},
+            "-10:-2:3",
+            r"(?s)r\.stop.*Input should be greater than 0",
+            id="pos-stop--10:-2:3",
+        ),
+        pytest.param(
+            {"start_type": pydantic.PositiveInt},
+            "-1:3",
+            r"(?s)r\.start.*Input should be greater than 0",
+            id="pos-start--1:3",
+        ),
     ],
 )
-def test_range_validation_errors(value: ty.Any) -> None:
+def test_range_validation_errors(
+    kwargs: dict[str, ty.Any], value: ty.Any, match: str
+) -> None:
     """Invalid inputs raise ValidationError."""
-    with pytest.raises(pydantic.ValidationError):
-        _Model(r=value)
+
+    class Model(pydantic.BaseModel):
+        r: ty.Annotated[range, RangeAdapter(**kwargs)]
+
+    with pytest.raises(pydantic.ValidationError, match=match):
+        Model(r=value)
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "exc_type", "match"),
+    [
+        pytest.param(
+            {"default_type": float},
+            ValueError,
+            "RangeAdapter: default_type was <class 'float'>, but only int's or "
+            "annotated int's are currently supported",
+            id="default-float",
+        ),
+        pytest.param(
+            {"start_type": ty.Annotated[float, 16], "stop_type": pydantic.PositiveInt},
+            ValueError,
+            r"RangeAdapter: start_type was typing.Annotated\[float, 16\], but "
+            "only int's or annotated int's are currently supported",
+            id="start-annotated-float",
+        ),
+        pytest.param(
+            {"stop_type": ty.Annotated[float, 16], "start_type": pydantic.PositiveInt},
+            ValueError,
+            r"RangeAdapter: stop_type was typing.Annotated\[float, 16\], but "
+            "only int's or annotated int's are currently supported",
+            id="stop-annotated-float",
+        ),
+        pytest.param(
+            {"step_type": ty.Annotated[float, 16]},
+            ValueError,
+            r"RangeAdapter: step_type was typing.Annotated\[float, 16\], but "
+            "only int's or annotated int's are currently supported",
+            id="step-annotated-float",
+        ),
+    ],
+)
+def test_invalid_kwargs(
+    kwargs: dict[str, ty.Any], exc_type: type[BaseException], match: str
+) -> None:
+    """Test an invalid configuration of RangeAdapter"""
+    with pytest.raises(exc_type, match=match):
+        RangeAdapter(**kwargs)
 
 
 @pytest.mark.parametrize(
@@ -57,14 +159,22 @@ def test_range_validation_errors(value: ty.Any) -> None:
 )
 def test_range_serialization(value: range, truth: str) -> None:
     """Range serializes to JSON-compatible mapping."""
-    model = _Model(r=value)
+
+    class Model(pydantic.BaseModel):
+        r: ty.Annotated[range, RangeAdapter()]
+
+    model = Model(r=value)
     assert model.model_dump() == {"r": value}
     assert model.model_dump(mode="json") == {"r": truth}
 
 
 def test_json_schema() -> None:
     """JSON schema is stable and well-defined."""
-    schema = _Model.model_json_schema()
+
+    class Model(pydantic.BaseModel):
+        r: ty.Annotated[range, RangeAdapter()]
+
+    schema = Model.model_json_schema()
     r = schema["properties"]["r"]
     assert r["type"] == "string"
     assert r["description"] == "Python range syntax: start:stop[:step]"

--- a/tests/test_range.py
+++ b/tests/test_range.py
@@ -114,29 +114,29 @@ def test_range_validation_errors(
         pytest.param(
             {"default_type": float},
             ValueError,
-            "RangeAdapter: default_type was <class 'float'>, but only int's or "
-            "annotated int's are currently supported",
+            "RangeAdapter: default_type was <class 'float'>, but only int "
+            "or an annotated int is currently supported",
             id="default-float",
         ),
         pytest.param(
             {"start_type": ty.Annotated[float, 16], "stop_type": pydantic.PositiveInt},
             ValueError,
             r"RangeAdapter: start_type was typing.Annotated\[float, 16\], but "
-            "only int's or annotated int's are currently supported",
+            "only int or an annotated int is currently supported",
             id="start-annotated-float",
         ),
         pytest.param(
             {"stop_type": ty.Annotated[float, 16], "start_type": pydantic.PositiveInt},
             ValueError,
             r"RangeAdapter: stop_type was typing.Annotated\[float, 16\], but "
-            "only int's or annotated int's are currently supported",
+            "only int or an annotated int is currently supported",
             id="stop-annotated-float",
         ),
         pytest.param(
             {"step_type": ty.Annotated[float, 16]},
             ValueError,
             r"RangeAdapter: step_type was typing.Annotated\[float, 16\], but "
-            "only int's or annotated int's are currently supported",
+            "only int or an annotated int is currently supported",
             id="step-annotated-float",
         ),
     ],
@@ -168,6 +168,17 @@ def test_range_serialization(value: range, truth: str) -> None:
     assert model.model_dump(mode="json") == {"r": truth}
 
 
+def test_with_non_range() -> None:
+    """Test that a non-range raises an error"""
+    with pytest.raises(
+        pydantic.PydanticSchemaGenerationError,
+        match="RangeAdapter must be used with range, not <class 'int'>",
+    ):
+
+        class Model(pydantic.BaseModel):
+            a: ty.Annotated[int, RangeAdapter()]
+
+
 def test_json_schema() -> None:
     """JSON schema is stable and well-defined."""
 
@@ -179,3 +190,51 @@ def test_json_schema() -> None:
     assert r["type"] == "string"
     assert r["description"] == "Python range syntax: start:stop[:step]"
     assert "pattern" in r
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        pytest.param(range(5), range(5), id="range(5)"),
+        pytest.param(":5", range(5), id=":5"),
+        pytest.param(" : 5", range(5), id=" : 5"),
+        pytest.param("1:5", range(1, 5), id="1:5"),
+        pytest.param(" 1\t:\n5 : ", range(1, 5), id=" 1 : 5 : "),
+        pytest.param("1:10:2", range(1, 10, 2), id="1:10:2"),
+    ],
+)
+def test_valid_deprecated_usage(value: ty.Any, expected: range) -> None:
+    """Test valid validation cases for the deprecated classmethod approach."""
+    with pytest.warns(DeprecationWarning, match="use a RangeAdapter instance"):
+
+        class Model(pydantic.BaseModel):
+            r: ty.Annotated[range, RangeAdapter]
+
+    model = Model(r=value)
+    assert model.r == expected
+
+
+@pytest.mark.parametrize(
+    ("value", "match"),
+    [
+        pytest.param(
+            123,
+            "expected range or slice-syntax string, got int",
+            id="invalid_range",
+        ),
+        pytest.param(
+            "5",
+            "invalid range syntax, expected 2-3 parts separated by :'s, got 1",
+            id="5",
+        ),
+    ],
+)
+def test_deprecated_range_validation_errors(value: ty.Any, match: str) -> None:
+    """Invalid inputs raise ValidationError and raise a deprecation warning."""
+    with pytest.warns(DeprecationWarning, match="use a RangeAdapter instance"):
+
+        class Model(pydantic.BaseModel):
+            r: ty.Annotated[range, RangeAdapter]
+
+    with pytest.raises(pydantic.ValidationError, match=match):
+        Model(r=value)

--- a/uv.lock
+++ b/uv.lock
@@ -1447,7 +1447,7 @@ wheels = [
 
 [[package]]
 name = "scientific-pydantic"
-version = "0.4.0"
+version = "0.5.0a1"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
This PR deprecates the use of `RangeAdapter` as a bare class in an `Annotated`, in favor of using a `RangeAdapter` instance.

This brings `RangeAdapter` in line with the majority of the rest of the library and allows for constrained integers as annotations for the start/stop/step. This can allow, for example, the user to express that all three fields of a range must be positive, or that the step must be negative for a reverse range.